### PR TITLE
fix(big-sur): resolve issues with building and native-comp on Big Sur

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -298,6 +298,11 @@ class Build
         "#{brew_dir}/opt/texinfo/bin",
         ENV['PATH']
       ].compact.join(':')
+      
+      ENV['LIBRARY_PATH'] = [
+         ENV['LIBRARY_PATH'],
+         "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+        ].compact.join(':')
 
       configure_flags = [
         '--with-ns',

--- a/patches/native-comp-env-setup.patch
+++ b/patches/native-comp-env-setup.patch
@@ -2,7 +2,7 @@ diff --git a/lisp/emacs-lisp/comp.el b/lisp/emacs-lisp/comp.el
 index 25e2de9..bcedd31 100644
 --- a/lisp/emacs-lisp/comp.el
 +++ b/lisp/emacs-lisp/comp.el
-@@ -2801,6 +2801,53 @@ queued with LOAD %"
+@@ -2801,6 +2801,57 @@ queued with LOAD %"
        (comp-run-async-workers)
        (message "Compilation started."))))
  
@@ -13,6 +13,8 @@ index 25e2de9..bcedd31 100644
 +             (string-match-p "\.app\/Contents\/MacOS\/?$"
 +                             invocation-directory))
 +    (let* ((library-path-env (getenv "LIBRARY_PATH"))
++           (devtools-dir
++            "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib")
 +           (gcc-base-dir (concat invocation-directory "lib/gcc"))
 +           (gcc-version (car (seq-filter
 +                              (lambda (dir) (string-match-p "^[0-9]+$" dir))
@@ -28,6 +30,8 @@ index 25e2de9..bcedd31 100644
 +           (darwin-dir (concat darwin-base-dir "/" darwin-version))
 +           (lib-paths (append
 +                       (list gcc-dir darwin-dir)
++                       (if (file-directory-p devtools-dir)
++                           (list devtools-dir) (list))
 +                       (if library-path-env (list library-path-env) (list)))))
 +
 +      (when (and gcc-dir darwin-dir)


### PR DESCRIPTION
This incorporates @claford-v-lawrence's PR #25, with the addition of adding the Xcode CLI tools lib path to the runtime `LIBRARY_PATH` via the native-comp-env-setup patch.

I've fired off a build with these changes on Catalina from commit [bd693cc](https://github.com/emacs-mirror/emacs/commit/bd693ccea7ba4a6aafda103f7a9166f76363c86b) to confirm everything still works.

@AllenDang, @claford-v-lawrence would you two be able to test this on Big Sur, without the `(setenv "LIBRARY_PATH" ...` snippet in your config I posted on #25.

Confirmations:

- Catalina:
  - [x] Build succeeds
  - [x] Native-comp works
- Big Sur:
  - [ ] Build succeeds
  - [ ] Native-comp works