### PR TITLE
feat(codesign): minor internal fix to output Emacs.app bundle for compatibility with codesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ available here: https://github.com/emacs-mirror/emacs
 Options:
     -j, --parallel COUNT             Compile using COUNT parallel processes (detected: 8)
         --git-sha SHA                Override detected git SHA of specified branch allowing builds of old commits
-        --[no-]xwidgets              Enable/disable XWidgets (default: enabled if supported)
+        --[no-]xwidgets              Enable/disable XWidgets if supported (default: enabled)
         --[no-]native-comp           Enable/disable native-comp (default: enabled if supported)
         --[no-]native-full-aot       Enable/disable NATIVE_FULL_AOT / Ahead of Time compilation (default: disabled)
-        --rsvg                       Enable SVG image support via librsvg, can yield a unstable build (default: disabled)
+        --[no-]rsvg                  Enable/disable SVG image support via librsvg (default: enabled)
         --no-titlebar                Apply no-titlebar patch (default: disabled)
         --no-frame-refocus           Apply no-frame-refocus patch (default: disabled)
-        --[no-]native-fast-boot      DEPRECATED: use --[no-]native-full-aot instead
-        --[no-]launcher              DEPRECATED: Launcher script is no longer used.
+        --work-dir DIR               Specify a working directory where tarballs, sources, and builds will be stored and worked with
+        --plan FILE                  Follow given plan file, instead of using given git ref/sha
 ```
 
 Resulting applications are saved to the `builds` directory in a bzip2 compressed

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -585,7 +585,7 @@ class AbstractEmbedder
   private
 
   def invocation_dir
-    File.join(app, 'Contents/MacOS')
+    File.join(app, 'Contents', 'MacOS')
   end
 
   def bin

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -713,7 +713,9 @@ class GccLibEmbedder < AbstractEmbedder
 
     FileUtils.mkdir_p(File.dirname(target_dir))
     FileUtils.cp_r(source_dir, target_dir)
-    FileUtils.rm(Dir[File.join(target_dir, '**/.DS_Store')], force: true)
+    FileUtils.rm(Dir[File.join(target_dir, '**', '.DS_Store')], force: true)
+    FileUtils.chmod_R('u+w', target_dir)
+    FileUtils.mv(source_darwin_dir, target_darwin_dir)
   end
 
   private
@@ -726,8 +728,20 @@ class GccLibEmbedder < AbstractEmbedder
     File.join(invocation_dir, gcc_info.relative_lib_dir)
   end
 
+  def source_darwin_dir
+    File.join(invocation_dir, gcc_info.relative_darwin_lib_dir)
+  end
+
+  def target_darwin_dir
+    File.join(invocation_dir, gcc_info.sanitized_relative_darwin_lib_dir)
+  end
+
   def source_dir
     gcc_info.lib_dir
+  end
+
+  def relative_dir(path, root)
+    Pathname.new(path).relative_path_from(Pathname.new(root)).to_s
   end
 end
 
@@ -766,6 +780,17 @@ class GccInfo
 
   def relative_darwin_lib_dir
     @relative_darwin_lib_dir ||= relative_dir(darwin_lib_dir, root_dir)
+  end
+
+  # Sanitize folder name with full "MAJOR.MINOR.PATCH" version number to just
+  # the MAJOR version. Apple's codesign CLI tool throws a "bundle format
+  # unrecognized" error if there are any folders with two dots in their name
+  # within the Emacs.app application bundle.
+  def sanitized_relative_darwin_lib_dir
+    @sanitized_relative_darwin_lib_dir ||= File.join(
+      File.dirname(relative_darwin_lib_dir),
+      File.basename(relative_darwin_lib_dir).split('.').first
+    )
   end
 
   def libgccjit_root_dir
@@ -812,10 +837,7 @@ class GccInfo
   private
 
   def relative_dir(path, root)
-    root += '/' unless root[-1] == '/'
-    return if path[0..root.size - 1] != root
-
-    path[root.size..-1]
+    Pathname.new(path).relative_path_from(Pathname.new(root)).to_s
   end
 end
 

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -628,9 +628,14 @@ class LibEmbedder < AbstractEmbedder
       Pathname.new(File.dirname(exe))
     ).to_s
 
-    while_writable(exe) do
-      system('install_name_tool', '-add_rpath',
-             File.join('@executable_path', rel_path), exe)
+    rpath = File.join('@executable_path', rel_path)
+    rpaths = `otool -l "#{exe}" | grep -A 2 'cmd LC_RPATH' | grep 'path'`
+
+    unless rpaths.include?(rpath)
+      while_writable(exe) do
+        system('install_name_tool', '-add_rpath',
+               File.join('@executable_path', rel_path), exe)
+      end
     end
 
     `otool -L "#{exe}"`.split("\n")[1..-1].each do |line|

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -863,7 +863,7 @@ if __FILE__ == $PROGRAM_NAME
 
       opts.on('-j', '--parallel COUNT',
               'Compile using COUNT parallel processes ' \
-              "(default: #{cli_options[:parallel]})") do |v|
+              "(detected: #{cli_options[:parallel]})") do |v|
         cli_options[:parallel] = v
       end
 
@@ -917,23 +917,6 @@ if __FILE__ == $PROGRAM_NAME
         'Follow given plan file, instead of using given git ref/sha'
       ) do |v|
         cli_options[:plan] = v
-      end
-
-      opts.on('--[no-]native-fast-boot',
-              'DEPRECATED: use --[no-]native-full-aot instead') do |v|
-        if v
-          raise Error, '--native-fast-boot option is deprecated, ' \
-                       'use --no-native-full-aot instead'
-        else
-          raise Error, '--no-native-fast-boot option is deprecated, ' \
-                       'use --native-full-aot instead'
-        end
-      end
-
-      opts.on('--[no-]launcher',
-              'DEPRECATED: Launcher script is no longer used.') do |_|
-        raise Error, '--[no-]launcher option is deprecated, launcher ' \
-                     'script is no longer used.'
       end
     end.parse!
 

--- a/patches/native-comp-env-setup.diff.erb
+++ b/patches/native-comp-env-setup.diff.erb
@@ -1,10 +1,10 @@
 diff --git a/lisp/emacs-lisp/comp.el b/lisp/emacs-lisp/comp.el
-index 4036080976..2ff8dbd74c 100644
+index 8c638312b0..87af889ef4 100644
 --- a/lisp/emacs-lisp/comp.el
 +++ b/lisp/emacs-lisp/comp.el
-@@ -4079,6 +4079,52 @@ of (commands) to run simultaneously."
+@@ -4215,6 +4215,52 @@ native-compile-async
    (let ((load (not (not load))))
-     (native--compile-async paths recursively load selector)))
+     (native--compile-async files recursively load selector)))
  
 +;;;###autoload
 +(defun native-compile-setup-environment-variables (&rest _args)
@@ -19,7 +19,7 @@ index 4036080976..2ff8dbd74c 100644
 +                     "<%= relative_lib_dir %>"
 +                     invocation-directory))
 +           (darwin-dir (expand-file-name
-+                        "<%= relative_darwin_lib_dir %>"
++                        "<%= sanitized_relative_darwin_lib_dir %>"
 +                        invocation-directory))
 +           (lib-paths (list)))
 +
@@ -54,4 +54,4 @@ index 4036080976..2ff8dbd74c 100644
 +
  (provide 'comp)
  
- ;;; comp.el ends here
+ ;; LocalWords: limplified limplified limplification limplify Limple LIMPLE libgccjit elc eln


### PR DESCRIPTION
This simply addresses a folder name within Emacs.app which was causing
`codesign` to throw a fatal error when trying to sign the application bundle.