### PR TITLE
fix: improve portability of builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Options:
         --git-sha SHA                Override detected git SHA of specified branch allowing builds of old commits
         --[no-]xwidgets              Enable/disable XWidgets if supported (default: enabled)
         --[no-]native-comp           Enable/disable native-comp (default: enabled if supported)
+        --[no-]native-march          Enable/disable -march=native CFLAG(default: disabled)
         --[no-]native-full-aot       Enable/disable NATIVE_FULL_AOT / Ahead of Time compilation (default: disabled)
         --[no-]rsvg                  Enable/disable SVG image support via librsvg (default: enabled)
         --no-titlebar                Apply no-titlebar patch (default: disabled)

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -267,7 +267,7 @@ class Build
           "-I#{File.join(gcc_info.root_dir, 'include')}",
           "-I#{File.join(gcc_info.libgccjit_root_dir, 'include')}",
           '-O2',
-          '-march=native',
+          (options[:native_march] ? '-march=native' : nil),
           ENV['CFLAGS']
         ].compact.join(' ')
 
@@ -904,6 +904,7 @@ if __FILE__ == $PROGRAM_NAME
   cli_options = {
     work_dir: File.expand_path(__dir__),
     native_full_aot: false,
+    native_march: false,
     parallel: Etc.nprocessors,
     rsvg: true,
     xwidgets: true,
@@ -943,6 +944,12 @@ if __FILE__ == $PROGRAM_NAME
               'Enable/disable native-comp ' \
               '(default: enabled if supported)') do |v|
         cli_options[:native_comp] = v
+      end
+
+      opts.on('--[no-]native-march',
+              'Enable/disable -march=native CFLAG' \
+              '(default: disabled)') do |v|
+        cli_options[:native_march] = v
       end
 
       opts.on('--[no-]native-full-aot',

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -652,10 +652,34 @@ class LibEmbedder < AbstractEmbedder
     FileUtils.cd(File.dirname(app)) do
       copy_libs(binary)
       copy_extra_libs(extra_libs, binary) if extra_libs.any?
+      if eln_files.any?
+        info "Embedding libraries for #{eln_files.size} *.eln files " \
+             'within Emacs.app'
+        rel_path = Pathname.new(lib_dir).relative_path_from(
+          Pathname.new(File.dirname(binary))
+        ).to_s
+        eln_files.each { |f| copy_libs(f, rel_path) }
+      end
     end
   end
 
   private
+
+  def eln_files
+    @eln_files ||= Dir[
+      File.join(
+        app, 'Contents', 'Resources', 'native-lisp', '**', '*.eln'
+      ),
+      File.join(
+        app, 'Contents', 'MacOS', 'lib', 'emacs', '**',
+        'native-lisp', '**', '*.eln'
+      ),
+      File.join(
+        app, 'Contents', 'MacOS', 'libexec', 'emacs', '**',
+        'eln-cache', '**', '*.eln'
+      )
+    ]
+  end
 
   def copy_libs(exe, rel_path = nil)
     exe_file = File.basename(exe)


### PR DESCRIPTION
- Allows makes builds less specific to the exact CPU it is built on, meaning if
  it works one x86_64 Intel-based Mac, it should work on another, which was not
  always the case before.
- Fixed issue where native-comp builds required the `gcc` homebrew package to be
  installed.