### PR TITLE
fix(site-lisp): add Homebrew's site-lisp directory to locallisppath

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -359,7 +359,8 @@ class Build
         '--with-modules',
         '--enable-locallisppath=' \
         '/Library/Application Support/Emacs/${version}/site-lisp:' \
-        '/Library/Application Support/Emacs/site-lisp'
+        '/Library/Application Support/Emacs/site-lisp:' \
+        '/usr/local/share/emacs/site-lisp'
       ]
       if options[:xwidgets] && supports_xwidgets?
         configure_flags << '--with-xwidgets'


### PR DESCRIPTION
This should allow mu4e to be loaded from the mu homebrew package, among
other homebrew packages that provides emacs site-lisp files.

Ref: https://github.com/jimeh/emacs-builds/issues/19