### PR TITLE
Fix compatibility for libgccjit-12

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -682,6 +682,18 @@ class Build
       }
     end
 
+    if %w[emacs-28 emacs-29].include?(effective_version)
+      p << {
+        replace: [
+          'configure.ac',
+          'grep -E \'libgccjit\.(so|dylib)$\'))"',
+          'grep -E \'libgccjit\.(so|dylib)$\' | grep -E \'current\'))"'
+        ],
+        allow_failure: true
+      }
+    end
+
+
     if effective_version == 'emacs-27'
       p << {
         url: 'https://github.com/d12frosted/homebrew-emacs-plus/raw/master/' \


### PR DESCRIPTION
This actually should be fixed in the `emacs` itself sooner or later, but their patch acception process appears to be too complex.

This also might be a bit too hacky, please close if you want to do it better!

Since the latest update of `libgccjit` in brew to version 12,
emacs does not build again. Problem is that now dylib exists
in multiple locations, and `MAC_CFLAGS` environment variable
is not filled correctly in `configure.ac`.
This commit fixes the issue.