### PR TITLE
fix(native-comp): compatibility with libgccjit 12 homebrew formula

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -675,8 +675,8 @@ class Build
       p << {
         replace: [
           'configure.ac',
-          'grep libgccjit.so\$))"',
-          'grep -E \'libgccjit\.(so|dylib)$\'))"'
+          'grep libgccjit.so\$',
+          'grep -E \'libgccjit\.(so|dylib)$\''
         ],
         allow_failure: true
       }
@@ -686,8 +686,8 @@ class Build
       p << {
         replace: [
           'configure.ac',
-          'grep -E \'libgccjit\.(so|dylib)$\'))"',
-          'grep -E \'libgccjit\.(so|dylib)$\' | tail -1))"'
+          'grep -E \'libgccjit\.(so|dylib)$\'',
+          'grep -E \'libgccjit\.(so|dylib)$\' | tail -1'
         ],
         allow_failure: true
       }

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -682,6 +682,17 @@ class Build
       }
     end
 
+    if %w[emacs-28 emacs-29].include?(effective_version)
+      p << {
+        replace: [
+          'configure.ac',
+          'grep -E \'libgccjit\.(so|dylib)$\'))"',
+          'grep -E \'libgccjit\.(so|dylib)$\' | tail -1))"'
+        ],
+        allow_failure: true
+      }
+    end
+
     if effective_version == 'emacs-27'
       p << {
         url: 'https://github.com/d12frosted/homebrew-emacs-plus/raw/master/' \


### PR DESCRIPTION
Based on #74 and tweaked slightly, this resolves the recent build issues with
the libgccjit v12 formula which has two directories that contain the .dylib
file.