### PR TITLE
fix(deps): remove needless deps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,7 +2,6 @@
 
 brew 'autoconf'
 brew 'coreutils'
-brew 'curl'
 brew 'dbus'
 brew 'expat'
 brew 'gcc'

--- a/Brewfile.ci
+++ b/Brewfile.ci
@@ -1,3 +1,1 @@
 # frozen_string_literal: true
-
-brew 'python'


### PR DESCRIPTION
- Remove `curl` formula from `Brewfile` because it's a keg-only formula.
- Remove `python` from `Brewfile.ci`, as installing it on GitHub Action's
  `macOS-11` fails right now. And using system Python to install `dmgbuild`
  works fine.