### PR TITLE
feat: Add option for max file descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
         --[no-]relink-eln-files      Enable/disable re-linking shared libraries in bundled *.eln files (default: enabled)
         --[no-]rsvg                  Enable/disable SVG image support via librsvg (default: enabled)
         --[no-]poll                  Enable/disable experimental use of poll() instead of select() to support > 1024 file descriptors (default: disabled)
-        --fd-setsize 2048            Set an arbitrary file descriptor size. To be used in tandem with the `--poll` option (default: disabled)
+        --fd-setsize 2048            Set an arbitrary file descriptor size (default: disabled)
         --no-titlebar                Apply no-titlebar patch (default: disabled)
         --posix-spawn                Apply posix-spawn patch (default: disabled)
         --no-frame-refocus           Apply no-frame-refocus patch (default: disabled)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
         --[no-]relink-eln-files      Enable/disable re-linking shared libraries in bundled *.eln files (default: enabled)
         --[no-]rsvg                  Enable/disable SVG image support via librsvg (default: enabled)
         --[no-]poll                  Enable/disable experimental use of poll() instead of select() to support > 1024 file descriptors (default: disabled)
+        --fd-setsize 2048            Set an arbitrary file descriptor size. To be used in tandem with the `--poll` option (default: disabled)
         --no-titlebar                Apply no-titlebar patch (default: disabled)
         --posix-spawn                Apply posix-spawn patch (default: disabled)
         --no-frame-refocus           Apply no-frame-refocus patch (default: disabled)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Options:
         --[no-]native-full-aot       Enable/disable NATIVE_FULL_AOT / Ahead of Time compilation (default: disabled)
         --[no-]relink-eln-files      Enable/disable re-linking shared libraries in bundled *.eln files (default: enabled)
         --[no-]rsvg                  Enable/disable SVG image support via librsvg (default: enabled)
+        --[no-]poll                  Enable/disable experimental use of poll() instead of select() to support > 1024 file descriptors (default: disabled)
         --no-titlebar                Apply no-titlebar patch (default: disabled)
         --posix-spawn                Apply posix-spawn patch (default: disabled)
         --no-frame-refocus           Apply no-frame-refocus patch (default: disabled)

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -1579,8 +1579,7 @@ if __FILE__ == $PROGRAM_NAME
 
         opts.on(
           '--fd-setsize SIZE',
-          'Set an arbitrary file descriptor size. To be used in tandem ' \
-          'with the `--poll` option (default: disabled)'
+          'Set an arbitrary file descriptor size (default: disabled)'
         ) { |v| cli_options[:fd_setsize] = v }
 
         opts.on(

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -457,7 +457,7 @@ class Build
         configure_flags << '--with-tree-sitter'
       end
       if options[:fd_setsize]
-        configure_flags << "CFLAGS=-DFD_SETSIZE=#{options[:fd_setsize]}"
+        configure_flags << "CFLAGS=-DFD_SETSIZE=#{options[:fd_setsize]} -DDARWIN_UNLIMITED_SELECT"
       end
       configure_flags << native_comp_configure_flag if options[:native_comp]
       configure_flags << '--without-rsvg' if options[:rsvg] == false

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -456,6 +456,9 @@ class Build
       if options[:tree_sitter] && supports_tree_sitter?
         configure_flags << '--with-tree-sitter'
       end
+      if options[:fd_setsize]
+        configure_flags << "CFLAGS=-DFD_SETSIZE=#{options[:fd_setsize]}"
+      end
       configure_flags << native_comp_configure_flag if options[:native_comp]
       configure_flags << '--without-rsvg' if options[:rsvg] == false
       configure_flags << '--without-dbus' if options[:dbus] == false
@@ -1573,6 +1576,12 @@ if __FILE__ == $PROGRAM_NAME
           'to support > 1024 file descriptors ' \
           '(default: disabled)'
         ) { |v| cli_options[:poll] = v }
+
+        opts.on(
+          '--fd-setsize SIZE',
+          'Set an arbitrary file descriptor size. To be used in tandem ' \
+          'with the `--poll` option (default: disabled)'
+        ) { |v| cli_options[:fd_setsize] = v }
 
         opts.on(
           '--github-src-repo REPO',

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -380,18 +380,19 @@ class Build
     info 'Compiling from source. This will take a while...'
 
     FileUtils.cd(source) do
+      configure_cflags = [ENV.fetch('CFLAGS', nil)]
+
       if options[:native_comp]
         info 'Compiling with native-comp enabled'
         verify_native_comp
         gcc_info.verify_libgccjit
 
-        ENV['CFLAGS'] = [
+        configure_cflags.concat([
           "-I#{File.join(gcc_info.root_dir, 'include')}",
           "-I#{File.join(gcc_info.libgccjit_root_dir, 'include')}",
           '-O2',
           (options[:native_march] ? '-march=native' : nil),
-          ENV.fetch('CFLAGS', nil)
-        ].compact.join(' ')
+        ])
 
         ENV['LDFLAGS'] = [
           "-L#{gcc_info.lib_dir}",
@@ -457,11 +458,16 @@ class Build
         configure_flags << '--with-tree-sitter'
       end
       if options[:fd_setsize]
-        configure_flags << "CFLAGS=-DFD_SETSIZE=#{options[:fd_setsize]} -DDARWIN_UNLIMITED_SELECT"
+        configure_cflags.concat([
+          "-DFD_SETSIZE=#{options[:fd_setsize]}",
+          "-DDARWIN_UNLIMITED_SELECT",
+        ])
       end
       configure_flags << native_comp_configure_flag if options[:native_comp]
       configure_flags << '--without-rsvg' if options[:rsvg] == false
       configure_flags << '--without-dbus' if options[:dbus] == false
+
+      ENV['CFLAGS'] = configure_cflags.compact.join(' ')
 
       run_cmd './configure', *configure_flags.compact
 


### PR DESCRIPTION
People usually change the macOS system-level max file descriptors limits. Unfortunately, this doesn't change the value of `FD_SETSIZE` which is compiled into Emacs, which is used over the system-level size(s).

This options lets users specify an integer value for the `CFLAGS` option `FD_SETSIZE`.

This was based on the helpful work by Jiacai Liu [1].

I built Emacs with ` ./build-emacs-for-macos --native-full-aot --native-march --git-sha 9a2088b --no-archive emacs-30`. That SHA was chosen from the current Homebrew recipe [2], that I'm using as my daily driver.

When I evaluated `(message (shell-command-to-string "ulimit -n"))`, it printed `1024.`

I then built it again, this time adding `--fd-setsize 2048`. When I evaluated that same Elisp, it printed `2048`, as expected!

That I could actually open that many file descriptors was confirmed with the same test [1].

[1] https://en.liujiacai.net/2022/09/03/emacs-maxopenfiles/
[2] https://github.com/jimeh/homebrew-emacs-builds/blob/fc3103965c2e46665c7b085033ac6a40ee6a316d/Casks/emacs-app-monthly.rb#L12C115-L12C122

FIXES #106
