### PR TITLE
feat(builder/plan): add build variant flag

### DIFF
--- a/pkg/cli/plan.go
+++ b/pkg/cli/plan.go
@@ -38,6 +38,10 @@ func planCmd() *cli2.Command {
 				Name:  "sha",
 				Usage: "override commit SHA of specified git branch/tag",
 			},
+			&cli2.IntFlag{
+				Name:  "build-variant",
+				Usage: "build variant to add to the end of the version string",
+			},
 			&cli2.StringFlag{
 				Name:    "format",
 				Aliases: []string{"f"},
@@ -90,6 +94,7 @@ func planAction(c *cli2.Context, opts *Options) error {
 		EmacsRepo:     c.String("emacs-repo"),
 		Ref:           ref,
 		SHAOverride:   c.String("sha"),
+		BuildVariant:  c.Int("build-variant"),
 		OutputDir:     c.String("output-dir"),
 		TestBuild:     c.String("test-build"),
 		TestBuildType: plan.Prerelease,

--- a/pkg/plan/create.go
+++ b/pkg/plan/create.go
@@ -35,6 +35,7 @@ type Options struct {
 	EmacsRepo     string
 	Ref           string
 	SHAOverride   string
+	BuildVariant  int
 	OutputDir     string
 	TestBuild     string
 	TestBuildType TestBuildType
@@ -93,6 +94,12 @@ func Create(ctx context.Context, opts *Options) (*Plan, error) { //nolint:funlen
 	default:
 		version = absoluteVersion
 		releaseName = "Emacs." + version
+	}
+
+	if opts.BuildVariant != 0 {
+		variant := strconv.Itoa(opts.BuildVariant)
+		absoluteVersion += "-" + variant
+		releaseName += "-" + variant
 	}
 
 	// Attempt to get the macOS SDK version from the environment, if it's not


### PR DESCRIPTION
This will allow planning numbered build variants for the same Emacs version.

For example, if Emacs-30.1 has been built and published already, and
changes/fixes in the build system require updating the 30.1 build, we can now
publish it as "Emacs-30.1-1".