### PR TITLE
fix(builder/plan): append test build name to release name

### DIFF
--- a/pkg/plan/create.go
+++ b/pkg/plan/create.go
@@ -146,7 +146,7 @@ func Create(ctx context.Context, opts *Options) (*Plan, error) { //nolint:funlen
 
 		plan.Build.Name += ".test." + testName
 		plan.Release.Title = "Test Builds (" + testName + ")"
-		plan.Release.Name = "test-builds"
+		plan.Release.Name = "test-builds-" + testName
 
 		plan.Release.Prerelease = false
 		plan.Release.Draft = true


### PR DESCRIPTION
This ensures test builds are kept separate, rather than all just stomping over
each other when the release name is "test-builds".