### PR TITLE
fixes #142: prevent nil error for major and minor version parsing

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -164,11 +164,11 @@ class AbstractVersion
   end
 
   def major
-    @major ||= @version[:major]&.to_i
+    @major ||= (@version && @version[:major]) ? @version[:major].to_i : 0
   end
 
   def minor
-    @minor ||= @version[:minor]&.to_i
+    @minor ||= (@version && @version[:minor]) ? @version[:minor].to_i : 0
   end
 
   def patch

--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -150,9 +150,11 @@ class AbstractVersion
   attr_reader :version
 
   def initialize
-    @version = load_version.match(
+    str = load_version.strip
+    @version = str.match(
       /(?<major>\d+)(?:\.(?<minor>\d+)(?:\.(?<patch>\d+))?)?/
     )
+    warn "Parsed OS version string: '#{str}' => #{@version ? @version[0] : 'NIL'}"
   end
 
   def load_version
@@ -172,7 +174,7 @@ class AbstractVersion
   end
 
   def patch
-    @patch ||= @version[:patch]&.to_i
+    @patch ||= (@version && @version[:patch]) ? @version[:patch].to_i : 0
   end
 end
 


### PR DESCRIPTION

update major and minor methods to safely handle nil values in @version hash ensure integer conversion only when keys exist, otherwise default to 0 prevents exceptions if @version or keys are missing