### PR TITLE
fix(patches): add 30.x patches

### DIFF
--- a/build-emacs-for-macos
+++ b/build-emacs-for-macos
@@ -1102,6 +1102,19 @@ class Build
       }
     end
 
+    if effective_version == 30
+      p << {
+        url:
+        'https://github.com/d12frosted/homebrew-emacs-plus/raw/master/' \
+        'patches/emacs-30/fix-macos-tahoe-scrolling.patch'
+      }
+      p << {
+        url:
+        'https://github.com/d12frosted/homebrew-emacs-plus/raw/master/' \
+        'patches/emacs-30/treesit-compatibility.patch'
+      }
+    end
+
     if (27..31).include?(effective_version)
       p << {
         url:


### PR DESCRIPTION
Added new patches for 30.x

- [Tahoe scrolling](https://github.com/d12frosted/homebrew-emacs-plus/blob/master/patches/emacs-30/fix-macos-tahoe-scrolling.patch)
- [Treesitter compatibility](https://github.com/d12frosted/homebrew-emacs-plus/blob/master/patches/emacs-30/treesit-compatibility.patch)